### PR TITLE
Automate copying and testing existence of required files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: # No language needed, as python is already installed in the autograder docker image
+
 services:
     - docker
 
@@ -7,4 +8,4 @@ before_install:
 
 script:
     - docker run autograder /bin/sh -c "cd /autograder/source && python3 -m unittest discover -v -s metatests"
-    - docker run autograder /bin/sh -c "chmod +x source/metatests/integration_test.sh && ./source/metatests/integration_test.sh"
+    - chmod +x metatests/dispatch_integration_tests.sh && ./metatests/dispatch_integration_tests.sh

--- a/copy_files.py
+++ b/copy_files.py
@@ -1,0 +1,58 @@
+"""Module to copy files from one directory to another
+
+The files are listed in a text file, one to a line
+
+Script arguments:
+    (Arguments given to this script if run from the command line)
+
+    - source_dir -- The directory where the files currently live
+    - dest_dir   -- The directory to where the files are to be copied
+    - fname_file_list -- The path to the text file containing the
+                            list of filenames to be copied
+
+Note that these script arguments correspond precisely to the function arguments
+"""
+from shutil import copyfile 
+import os.path
+import sys
+import traceback
+
+def copy_files(source_dir, dest_dir, fname_file_list):
+    """Copy files from one directory to another
+
+    See module documentation for more information.
+    Note that the function arguments align precisely with those to the module/script
+
+    If a file is not found, the FileNotFound error will be caught
+        and its stack trace printed
+    """
+
+    with open(fname_file_list, 'r') as f :
+        for line in f:
+            fname = line.strip()
+            fsource = os.path.join( source_dir, fname )
+            fdest = os.path.join( dest_dir, fname )
+            try:
+                copyfile( fsource, fdest )
+            except FileNotFoundError as e:
+                print("Caught error:")
+                print(traceback.format_exc()) # print error stack trace
+
+
+if __name__ == '__main__':
+
+    ## set defaults
+    source_dir = "/autograder/submission/"
+    dest_dir   = "/autograder/source/"
+
+    fname_file_list = "required_files.txt"
+    
+    ## check for command line arguments overriding defaults
+    if len(sys.argv) > 1:
+        source_dir = sys.argv[1]
+    if len(sys.argv) > 2:
+        dest_dir = sys.argv[2]
+    if len(sys.argv) > 3:
+        fname_file_list = sys.argv[3]
+
+    copy_files(source_dir, dest_dir, fname_file_list)

--- a/metatests/additional_sample_submissions/missing_required_file/required_files.txt
+++ b/metatests/additional_sample_submissions/missing_required_file/required_files.txt
@@ -1,0 +1,2 @@
+sample_module.py
+sample_report.ipynb

--- a/metatests/additional_sample_submissions/missing_required_file/results_expected.json
+++ b/metatests/additional_sample_submissions/missing_required_file/results_expected.json
@@ -8,12 +8,12 @@
         },
         {
             "name": "test_file_existence_1_sample_report_ipynb (test_file_existence.TestFileExistence)",
-            "score": 0.01,
+            "score": 0.00,
             "max_score": 0.01,
-            "output": "File \"sample_report.ipynb\" exists in your submission\n\n"
+            "output": "WARNING\n\nFile \"sample_report.ipynb\" DOES NOT exist in your submission\n\nTest Failed: False is not true\n"
         }
     ],
     "leaderboard": [],
     "execution_time": "0.00",
-    "score": 0.02
+    "score": 0.01
 }

--- a/metatests/additional_sample_submissions/missing_required_file/sample_module.py
+++ b/metatests/additional_sample_submissions/missing_required_file/sample_module.py
@@ -1,0 +1,17 @@
+import numpy as np
+import random
+
+def return_integer(dummy1=1, dummy2=2) :
+    return dummy1 + dummy2
+
+def return_integer_list(dummy1=1, dummy2=2) :
+    return [dummy1, dummy2]
+
+def return_float(dummy1=1., dummy2=2.) :
+    return dummy1 / dummy2
+
+def return_float_list(dummy1=1., dummy2=2.) :
+    return [dummy1, dummy2]
+
+def return_float_list(dummy1=1., dummy2=2.) :
+    return np.array([dummy1, dummy2])

--- a/metatests/dispatch_integration_tests.sh
+++ b/metatests/dispatch_integration_tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+## Script to dispatch all integration tests
+##  * Runs each integration test in a separate docker container
+##	* Runs one from the sample_submission directory
+##	* Discovers others from the metatests/additional_sample_submissions directory
+
+## Make script exit early if a command fails, as well as echo each command before executing it
+set -ev  
+
+dispatch_integration_test () {
+	echo "Dispatching integration tests with arguments:  $@"
+	docker run autograder /bin/sh -c \
+		"chmod +x source/metatests/integration_test.sh && ./source/metatests/integration_test.sh $@"
+}
+
+## run first integration test, with default parameters
+dispatch_integration_test
+
+## run additional integration tests
+##	* check all subdirectories of metatests/additional_sample_submissions
+for dirname in metatests/additional_sample_submissions/*; do
+	## Only dispatch an integration test if the subdirectory contains a results_expected.json file
+	if [[ -f "$dirname/results_expected.json" ]]; then
+		dispatch_integration_test "source/$dirname"
+	fi
+done
+

--- a/metatests/integration_test.sh
+++ b/metatests/integration_test.sh
@@ -1,13 +1,37 @@
 #!/usr/bin/env bash
 
-## Script to run integration tests (see metatests/readme.md)
+## Script to run a single integration test (see metatests/readme.md)
 ##	* Intended to be run in a docker container simulating
 ##		Gradescope's autograder, as defined in metatests/Dockerfile
 
 cd /autograder
 
-# Copy the sample submission into the correct directory
-cp -r source/sample_submission/ submission/ 
+## Set parameters based on script arguments
+if [[ $# -eq 0 ]]; then # zero arguments
+	## use defaults for the first integration test
+	source_dir="source/sample_submission"
+	required_files_dir="source/"
+elif [[ $# -eq 1 ]]; then # one argument
+	## same source and required_files directories
+	source_dir="$1"
+	required_files_dir="$source_dir"
+else	# two or more arguments
+	## different (non-default) source and required_files directories
+	source_dir="$1"
+	required_files_dir="$2"
+fi
+
+echo ""
+echo "###########"
+echo "## Running integration test for sample submission located at: $source_dir ##"
+echo "###########"
+echo ""
+
+# Copy the sample submission into the expected directory
+cp -r "$source_dir" submission/ 
+
+# Move the required_files.txt file to the expected location
+mv "$required_files_dir/required_files.txt" "source/required_files.txt"
 
 # Create the directory where results.json will live
 mkdir results 
@@ -22,4 +46,7 @@ cat results/results.json
 #	* Will return nonzero if the results differ
 python3 source/metatests/compare_autograder_results.py \
 	results/results.json \
-	submission/results_expected.json
+	"$source_dir/results_expected.json"
+
+
+

--- a/metatests/test_copy_files_script.py
+++ b/metatests/test_copy_files_script.py
@@ -1,0 +1,58 @@
+from copy_files import copy_files
+import unittest
+import os
+import sys
+
+class TestCopyFiles(unittest.TestCase):
+    """Test the script used to copy required files"""
+
+    def setUp(self):
+        self.path = "metatests/test_files/"
+        self.fname1 = "dummyfile1.txt"
+        self.fname2 = "dummyfile2.txt"
+        self.fname_missing = "dummyfile_missing.txt"
+
+        self.dest_dir = self.path+"file_copy_dest_dir"
+        os.makedirs(self.dest_dir, exist_ok=True)
+        self.assertTrue(os.path.isdir(self.dest_dir))
+
+        ## ensure the destination directory is empty
+        for dirpath, dirnames, files in os.walk(self.dest_dir):
+            self.assertEqual(len(files), 0)
+            break
+
+        self.fname_filelist = self.path+"file_list.txt"  ## will be created during tests
+
+
+    def test_simple(self):
+        with open(self.fname_filelist, 'w') as f:
+            print(self.fname1, file=f)
+            print(self.fname2, file=f)
+
+        copy_files(self.path, self.dest_dir, self.fname_filelist)
+        self.assertTrue(os.path.isfile(self.path+self.fname1))
+        self.assertTrue(os.path.isfile(self.path+self.fname2))
+
+
+    def test_missing(self):
+        with open(self.fname_filelist, 'w') as f:
+            print(self.fname1, file=f)
+            print(self.fname_missing, file=f)
+            print(self.fname2, file=f)
+
+        ## suppress output
+        sys.stdout = None
+        copy_files(self.path, self.dest_dir, self.fname_filelist)
+        sys.stdout = sys.__stdout__
+        self.assertTrue(os.path.isfile(self.path+self.fname1))
+        self.assertFalse(os.path.isfile(self.path+self.fname_missing))
+        self.assertTrue(os.path.isfile(self.path+self.fname2))
+
+    def tearDown(self):
+        ## remove all files in the destination directory
+        for dirpath, dirnames, files in os.walk(self.dest_dir):
+            for f in files:
+                os.remove(os.path.join(self.dest_dir,f))
+            break
+        
+        os.remove(self.fname_filelist)

--- a/metatests/test_files/dummyfile1.txt
+++ b/metatests/test_files/dummyfile1.txt
@@ -1,0 +1,1 @@
+Dummy file 1

--- a/metatests/test_files/dummyfile2.txt
+++ b/metatests/test_files/dummyfile2.txt
@@ -1,0 +1,1 @@
+Dummy file 2

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,2 +1,3 @@
 subprocess32 
 gradescope-utils 
+parameterized

--- a/required_files.txt
+++ b/required_files.txt
@@ -1,0 +1,2 @@
+sample_module.py
+sample_report.ipynb

--- a/run_autograder
+++ b/run_autograder
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
-## Set up autograder files
-cp /autograder/submission/sample_module.py /autograder/source/sample_module.py
-cp /autograder/submission/sample_report.ipynb /autograder/source/sample_report.ipynb
-
 cd /autograder/source
 
 ## Pull updates from git
 source update.sh
+
+## Copy required files from submission directory to testing directory
+python3 copy_files.py
 
 ## Run tests and save output
 python3 run_tests.py > /autograder/results/results.json

--- a/tests/test_file_existence.py
+++ b/tests/test_file_existence.py
@@ -1,19 +1,28 @@
 import unittest
 from gradescope_utils.autograder_utils.decorators import weight
-import os.path
+
+import os
+
+from parameterized import parameterized
+
+with open("required_files.txt", 'r') as f:
+    required_files = [ line.strip() for line in f ]
 
 
-class TestEvaluator(unittest.TestCase):
-    def setUp(self):
-        pass
+class TestFileExistence(unittest.TestCase):
 
+    @parameterized.expand(
+            [ (fname, fname, True) for fname in required_files ]
+    )
     @weight(0.01)
-    def test_py(self):
-        """Test existence of sample_module.py"""
-        self.assertTrue(os.path.isfile("sample_module.py"))
+    def test_file_existence(self, name, test_input, expected):
+        fileExists = os.path.isfile(test_input)
+        if fileExists:
+            status = "exists"
+        else:
+            print("WARNING\n")
+            status = "DOES NOT exist"
+        print("File \"{}\" {} in your submission\n".format(test_input, status))
+        self.assertTrue(fileExists)
 
-    @weight(0.01)
-    def test_ipynb(self):
-        """Test existence of sample_report.ipynb"""
-        self.assertTrue(os.path.isfile("sample_report.ipynb"))
 


### PR DESCRIPTION
The Gradescope autograder requires students' submission files to be copied into the testing directory. The demo autograder copied these files manually, with the autograder failing (with unhelpful output) if an expected file was missing.

Now required files are listed in a text file and the autograder copies them over automatically. Moreover, students now see file existence tests which fail if a required file is not present.