### PR TITLE
Add machinery to check for PR-blocking-todos during CI

### DIFF
--- a/.github/pr-blocking-todos/checkfortodos.py
+++ b/.github/pr-blocking-todos/checkfortodos.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
         fnameToCheck = sys.argv[1]
     else:
         print("Expected one argument -- path to the file to check for TODOs")
-        exit(2)
+        exit(3)
 
     statusCode = checkForTodos(fnameToCheck)
     if statusCode == 1:

--- a/.github/pr-blocking-todos/checkfortodos.py
+++ b/.github/pr-blocking-todos/checkfortodos.py
@@ -5,18 +5,31 @@ def isTodoLine(line):
 
     TODO lines are formatted like top-level markdown bullet points
     
-    * Starts with `*`
+    * Starts with `*` or `-`
+    * Doesn't have ` [x]` or ` [X]` as the following chars
     * No white space before the first character
     """
 
+    ## ensure line is a string
     if not isinstance(line, str):
         return False
-    if len(line) < 0:
+
+    ## check first character
+    if len(line) < 1:
         return False
     firstChar = line[0]
-    if firstChar == '*':
-        return True
-    return False
+    allowedStartingChars = {'*', '-'}
+    if firstChar not in allowedStartingChars:
+        return False
+
+    ## ensure following characters don't indicate a checked off list
+    if len(line) >= 5:
+        nextChars = line[1:5]
+        allowedNextChars = { ' [{}]'.format(x) for x in ('x', 'X') }
+        if nextChars in allowedNextChars:
+            return False
+
+    return True
 
 
 def checkForTodos(fnameToCheck):

--- a/.github/pr-blocking-todos/checkfortodos.py
+++ b/.github/pr-blocking-todos/checkfortodos.py
@@ -1,9 +1,29 @@
 import sys
 
+def isTodoLine(line):
+    """Check whether the given line (a string) is considered a TODO line
+
+    TODO lines are formatted like top-level markdown bullet points
+    
+    * Starts with `*`
+    * No white space before the first character
+    """
+
+    if not isinstance(line, str):
+        return False
+    if len(line) < 0:
+        return False
+    firstChar = line[0]
+    if firstChar == '*':
+        return True
+    return False
+
+
 def checkForTodos(fnameToCheck):
     """Check for file containing todos
 
     If there are TODOs found, print them
+    See documentation for `isTodoLine` for which lines are considered todos
 
     Return the exit code to return to the shell
 
@@ -24,7 +44,7 @@ def checkForTodos(fnameToCheck):
         ## attempt to open file
         with open(fnameToCheck, 'r') as f:
             for line in f:
-                if len(line) > 0 and line[0] == '*':
+                if isTodoLine(line):
                     ## TODOs have been found
                     return 1
 

--- a/.github/pr-blocking-todos/checkfortodos.py
+++ b/.github/pr-blocking-todos/checkfortodos.py
@@ -1,0 +1,64 @@
+import sys
+
+def checkForTodos(fnameToCheck):
+    """Check for file containing todos
+
+    If there are TODOs found, print them
+
+    Return the exit code to return to the shell
+
+    0 -- No TODOs; all is well
+    1 -- TODOs found
+    2 -- TODO file not found
+    3 -- No/ invalid TODO file name specified
+    """
+
+    ## ensure fnameToCheck is valid
+    if ( fnameToCheck is None 
+           or not isinstance(fnameToCheck, str) 
+           or len(fnameToCheck) < 1
+        ):
+        return 3
+
+    try:
+        ## attempt to open file
+        with open(fnameToCheck, 'r') as f:
+            for line in f:
+                if len(line) > 0 and line[0] == '*':
+                    ## TODOs have been found
+                    return 1
+
+    except FileNotFoundError:
+        ## file containing TODOs not found
+        return 2
+
+    ## no TODOs found; all is well
+    return 0
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) > 1:
+        fnameToCheck = sys.argv[1]
+    else:
+        print("Expected one argument -- path to the file to check for TODOs")
+        exit(2)
+
+    statusCode = checkForTodos(fnameToCheck)
+    if statusCode == 1:
+        print("TODOs have been found:  \n\n")
+        ## echo the TODOs file
+        with open(fnameToCheck, 'r') as f:
+            for line in f:
+                print(line)
+    elif statusCode == 2:
+        print(
+                "Could not find file with potential TODOs"
+                "\nThis file should still be present even if there are no"
+                "TODOs.  In such a case it can be empty"
+            )
+    elif statusCode == 3:
+        print("Invalid filename argument")
+
+    exit(statusCode)
+

--- a/.github/pr-blocking-todos/tests/test_checkfortodos.py
+++ b/.github/pr-blocking-todos/tests/test_checkfortodos.py
@@ -1,0 +1,72 @@
+from checkfortodos import checkForTodos, isTodoLine
+
+import unittest
+
+class TestCheckForTodos(unittest.TestCase):
+
+    def test_isTodoLine_yesAndNo(self):
+
+        startingChars = ["*", "-"]
+        todoLinesRaw = [
+                "{}",
+                "{} ",
+                "{} this is a line",
+                "{} here's a newline \n",
+                "{} now a tab \t",
+                "{}even with no space after the starting char",
+                "{} [ ]", 
+                "{} [ ] with stuff after",
+                "{} [Y] having the wrong fill-in character",
+            ]
+        todoLines = [ 
+                raw.format(startingChar) 
+                for raw in todoLinesRaw 
+                for startingChar in startingChars 
+            ] + [
+                "*- multiple start chars",
+                "-* again, multiple start chars",
+            ]
+
+        notTodoLinesRaw = [
+                " {} space before start char",
+                "\t{} tab before start char",
+                "text before start char {} (and after too)",
+                "{} [x]", 
+                "{} [X]", 
+                "{} [x] with stuff after",
+                "{} [X] with stuff after",
+            ]
+        notTodoLines = [ 
+                raw.format(startingChar) 
+                for raw in notTodoLinesRaw 
+                for startingChar in startingChars 
+            ] + [
+                "",
+                "\n",
+            ]
+                
+        for line in todoLines:
+            with self.subTest("expecting True:  line: `{}`".format(line)):
+                value = isTodoLine(line)
+                self.assertTrue(value, "line: `{}`".format(line))
+
+        for line in notTodoLines:
+            with self.subTest("expecting False:  line: `{}`".format(line)):
+                value = isTodoLine(line)
+                self.assertFalse(value, "line: `{}`".format(line))
+
+    def test_isTodoLine_invalid(self):
+
+        invalidInputLines = [
+                None,
+                10,
+                [1,2,3],
+            ]
+
+        for invalidLine in invalidInputLines:
+            with self.subTest("expecting False:  line: `{}`".format(invalidLine)):
+                value = isTodoLine(invalidLine)
+                self.assertFalse(value, "line: `{}`".format(invalidLine))
+
+
+

--- a/.github/pr-blocking-todos/tests/test_istodoline.py
+++ b/.github/pr-blocking-todos/tests/test_istodoline.py
@@ -1,8 +1,8 @@
-from checkfortodos import checkForTodos, isTodoLine
+from checkfortodos import isTodoLine
 
 import unittest
 
-class TestCheckForTodos(unittest.TestCase):
+class TestIsTodoLine(unittest.TestCase):
 
     def test_isTodoLine_yesAndNo(self):
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: pr-blocking-todos-CI
 
 on: [push]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push]
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Check for PR-blocking TODOs
+        env:
+          ACTION_PATH: .github/pr-blocking-todos
+          TODOS_FNAME: .pr-blocking-todos.md
+        run: |
+          python3 "$ACTION_PATH/checkfortodos.py" "$TODOS_FNAME"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,14 @@ name: pr-blocking-todos-CI
 on: [push]
 
 jobs:
-  env:
-    LOCAL_BIN_PATH: .github/pr-blocking-todos
-    SCRIPT_NAME: checkfortodos.py
-    TODOS_FNAME: .pr-blocking-todos.md
 
   test:
     runs-on: ubuntu-latest
+
+    env:
+      LOCAL_BIN_PATH: .github/pr-blocking-todos
+      SCRIPT_NAME: checkfortodos.py
+      TODOS_FNAME: .pr-blocking-todos.md
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
-name: pr-blocking-todos-CI
+name: CI
 
 on: [push]
 
 jobs:
 
-  test:
+  pr-blocking-todos:
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: pr-blocking-todos-CI
 on: [push]
 
 jobs:
+  env:
+    LOCAL_BIN_PATH: .github/pr-blocking-todos
+    SCRIPT_NAME: checkfortodos.py
+    TODOS_FNAME: .pr-blocking-todos.md
 
   test:
     runs-on: ubuntu-latest
@@ -17,10 +21,14 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Check for PR-blocking TODOs
+      - name: Unit tests for PR-blocking TODOs
         env:
-          ACTION_PATH: .github/pr-blocking-todos
-          TODOS_FNAME: .pr-blocking-todos.md
+            TEST_DIR_NAME: tests
         run: |
-          python3 "$ACTION_PATH/checkfortodos.py" "$TODOS_FNAME"
+          cd "$LOCAL_BIN_PATH"
+          python3 -m unittest discover -v -s "$TEST_DIR_NAME"
+
+      - name: Check for PR-blocking TODOs
+        run: |
+          python3 "$LOCAL_BIN_PATH/$SCRIPT_NAME" "$TODOS_FNAME"
 

--- a/.pr-blocking-todos.md
+++ b/.pr-blocking-todos.md
@@ -1,4 +1,4 @@
 Any lines in this file beginning with the `*` character 
 	will register as a pull-request blocking TODO
 
-No TODOs here!
+* Complete code review

--- a/.pr-blocking-todos.md
+++ b/.pr-blocking-todos.md
@@ -1,4 +1,4 @@
-Any lines in this file beginning with the `*` character 
-	will register as a pull-request blocking TODO
+Any lines in this file beginning with the `*` character will register as a pull-request blocking TODO
 
-* Complete code review
+No TODOs here.
+

--- a/.pr-blocking-todos.md
+++ b/.pr-blocking-todos.md
@@ -1,0 +1,4 @@
+Any lines in this file beginning with the `*` character 
+	will register as a pull-request blocking TODO
+
+No TODOs here!


### PR DESCRIPTION
This gives one the opportunity to "block" pull requests by editing a markdown file.

If there are any TODO items found in the `.pr-blocking-todos.md` file, a CI check visibly fails.  Of course one could ignore this and merge the pull request anyway, but at least this serves as a visible warning.